### PR TITLE
Set default timesteps to 3 years

### DIFF
--- a/src/services/CommonsService.js
+++ b/src/services/CommonsService.js
@@ -5,5 +5,5 @@ const simulationApiUrl = process.env.VUE_APP_SIMULATION_API_URL
 if (!simulationApiUrl) throw new Error('VUE_APP_SIMULATION_API_URL is missing from env.')
 
 export const CommonsService = {
-  fetch: data => axios.post(simulationApiUrl, data),
+  fetch: data => axios.post(simulationApiUrl, data, { timeout: 180000 }),
 }

--- a/src/store/modules/CommonsModule.js
+++ b/src/store/modules/CommonsModule.js
@@ -4,7 +4,7 @@ import { createModule } from '../store.utils'
 const simulationDefaults = {
   kappa: Number(process.env.VUE_APP_SIM_KAPPA ?? 3),
   vesting_80p_unlocked: Number(process.env.VUE_APP_SIM_VESTING_80P_UNLOCKED ?? 60),
-  timesteps_days: Number(process.env.VUE_APP_SIM_TIMESTEPS_DAYS ?? 90),
+  timesteps_days: Number(process.env.VUE_APP_SIM_TIMESTEPS_DAYS ?? 1095), // 3 years
   random_seed: Number(process.env.VUE_APP_SIM_RANDOM_SEED ?? 42)
 }
 


### PR DESCRIPTION
This PR set the default simulation timesteps to 3 years (1095). It also increases the timeout for the post request on the backend server to 3 minutes