### PR TITLE
Fix title

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
-    <title><%= htmlWebpackPlugin.options.title %></title>
+    <title><%= 'Commons Simulator' || htmlWebpackPlugin.options.title %></title>
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
This PR prevents the app from showing `web.client.js` as the tab title (it happens for some ms when we open the app).